### PR TITLE
seo: add JSON-LD structured data to about, contact, and projects pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,7 +27,7 @@
       "url": "https://thomas-schulze-it-solutions.de/",
       "jobTitle": "Softwarearchitekt & .NET-Freelancer",
       "image": "https://thomas-schulze-it-solutions.de/img/social-preview.png",
-      "email": "mailto:info@thomas-schulze-it-solutions.de",
+      "email": "info@thomas-schulze-it-solutions.de",
       "address": {
         "@type": "PostalAddress",
         "addressLocality": "Leipzig",

--- a/about.html
+++ b/about.html
@@ -13,6 +13,40 @@
   <meta property="og:site_name" content="Thomas Schulze IT Solutions" />
   <meta property="og:locale" content="de_DE" />
   <meta property="og:image" content="https://thomas-schulze-it-solutions.de/img/social-preview.png" />
+  <!-- JSON-LD structured data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    "url": "https://thomas-schulze-it-solutions.de/about.html",
+    "name": "Über mich – Thomas Schulze IT Solutions",
+    "description": "Freiberuflicher Softwarearchitekt und .NET-Entwickler mit Spezialisierung auf .NET/C#, Angular, React und Cloud-Technologien.",
+    "mainEntity": {
+      "@type": "Person",
+      "name": "Thomas Schulze",
+      "url": "https://thomas-schulze-it-solutions.de/",
+      "jobTitle": "Softwarearchitekt & .NET-Freelancer",
+      "image": "https://thomas-schulze-it-solutions.de/img/social-preview.png",
+      "email": "mailto:info@thomas-schulze-it-solutions.de",
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Leipzig",
+        "addressCountry": "DE"
+      },
+      "sameAs": [
+        "https://github.com/thoooschuuu",
+        "https://www.linkedin.com/in/thomas-schulze-it-solutions",
+        "https://www.freelancermap.de/profil/thomas-schulze-257276"
+      ],
+      "knowsAbout": ["C#", ".NET", "ASP.NET Core", "Angular", "React", "TypeScript", "Azure", "AWS", "Microservices", "REST APIs"],
+      "worksFor": {
+        "@type": "Organization",
+        "name": "Thomas Schulze IT Solutions",
+        "url": "https://thomas-schulze-it-solutions.de/"
+      }
+    }
+  }
+  </script>
   <link rel="icon" type="image/svg+xml" href="img/logo-icon.svg" />
   <script>
     (function () {

--- a/contact.html
+++ b/contact.html
@@ -13,6 +13,37 @@
   <meta property="og:site_name" content="Thomas Schulze IT Solutions" />
   <meta property="og:locale" content="de_DE" />
   <meta property="og:image" content="https://thomas-schulze-it-solutions.de/img/social-preview.png" />
+  <!-- JSON-LD structured data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "ContactPage",
+    "url": "https://thomas-schulze-it-solutions.de/contact.html",
+    "name": "Kontakt – Thomas Schulze IT Solutions",
+    "description": "Nehmen Sie Kontakt mit Thomas Schulze auf – freiberuflicher Software-Ingenieur. Verfügbar für neue Projekte, Beratung und Teamerweiterung.",
+    "mainEntity": {
+      "@type": "Organization",
+      "name": "Thomas Schulze IT Solutions",
+      "url": "https://thomas-schulze-it-solutions.de/",
+      "email": "mailto:info@thomas-schulze-it-solutions.de",
+      "founder": {
+        "@type": "Person",
+        "name": "Thomas Schulze",
+        "url": "https://thomas-schulze-it-solutions.de/"
+      },
+      "areaServed": [
+        { "@type": "Place", "name": "Europe (Remote)" },
+        { "@type": "Place", "name": "Leipzig Region (Remote & On-Site)" }
+      ],
+      "contactPoint": {
+        "@type": "ContactPoint",
+        "contactType": "customer service",
+        "email": "info@thomas-schulze-it-solutions.de",
+        "availableLanguage": ["German", "English"]
+      }
+    }
+  }
+  </script>
   <link rel="icon" type="image/svg+xml" href="img/logo-icon.svg" />
   <script>
     (function () {

--- a/contact.html
+++ b/contact.html
@@ -25,21 +25,21 @@
       "@type": "Organization",
       "name": "Thomas Schulze IT Solutions",
       "url": "https://thomas-schulze-it-solutions.de/",
-      "email": "mailto:info@thomas-schulze-it-solutions.de",
+      "email": "info@thomas-schulze-it-solutions.de",
       "founder": {
         "@type": "Person",
         "name": "Thomas Schulze",
         "url": "https://thomas-schulze-it-solutions.de/"
       },
       "areaServed": [
-        { "@type": "Place", "name": "Europe (Remote)" },
-        { "@type": "Place", "name": "Leipzig Region (Remote & On-Site)" }
+        { "@type": "Place", "name": "Europa (Remote)" },
+        { "@type": "Place", "name": "Region Leipzig (Remote & vor Ort)" }
       ],
       "contactPoint": {
         "@type": "ContactPoint",
         "contactType": "customer service",
         "email": "info@thomas-schulze-it-solutions.de",
-        "availableLanguage": ["German", "English"]
+        "availableLanguage": ["de", "en"]
       }
     }
   }

--- a/projects.html
+++ b/projects.html
@@ -13,6 +13,78 @@
   <meta property="og:site_name" content="Thomas Schulze IT Solutions" />
   <meta property="og:locale" content="de_DE" />
   <meta property="og:image" content="https://thomas-schulze-it-solutions.de/img/social-preview.png" />
+  <!-- JSON-LD: update itemListElement when new projects are added (see js/i18n.js projectsData) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "url": "https://thomas-schulze-it-solutions.de/projects.html",
+    "name": "Projekte – Thomas Schulze IT Solutions",
+    "description": "Eine Auswahl an Projekten von Thomas Schulze – freiberuflicher Software-Ingenieur mit Spezialisierung auf .NET, C#, Angular, React und Cloud-Lösungen.",
+    "author": {
+      "@type": "Person",
+      "name": "Thomas Schulze",
+      "url": "https://thomas-schulze-it-solutions.de/"
+    },
+    "mainEntity": {
+      "@type": "ItemList",
+      "name": "Projekthistorie Thomas Schulze",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "item": {
+            "@type": "CreativeWork",
+            "name": "Senior Software Engineer – Platform Team",
+            "description": "Zentrales Plattform-Team in einem großen Enterprise-System der Energiewirtschaft. Migration von .NET Framework auf .NET 8/10, NHibernate-Migration, Visual-Studio-Extension-Entwicklung.",
+            "creator": { "@type": "Person", "name": "Thomas Schulze" },
+            "provider": { "@type": "Organization", "name": "Groß, Weber & Partner" },
+            "startDate": "2025-08-01"
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "item": {
+            "@type": "CreativeWork",
+            "name": "Senior Software Engineer",
+            "description": "Entwicklung von Microservices für die Verwaltung und Verarbeitung von Stammdaten für die Messtechnik in der Energiewirtschaft.",
+            "creator": { "@type": "Person", "name": "Thomas Schulze" },
+            "provider": { "@type": "Organization", "name": "Groß, Weber & Partner" },
+            "startDate": "2023-01-01",
+            "endDate": "2025-08-31"
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "item": {
+            "@type": "CreativeWork",
+            "name": "Development / Architecture of an Integration Platform",
+            "description": "Entwicklung und Architektur einer Integrationsplattform für die Kommunikation zwischen Domänen und Services.",
+            "creator": { "@type": "Person", "name": "Thomas Schulze" },
+            "provider": { "@type": "Organization", "name": "SoftwareONE AG" },
+            "startDate": "2020-12-31",
+            "endDate": "2023-02-27"
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 4,
+          "item": {
+            "@type": "CreativeWork",
+            "name": "Co-Founder and Lead API Council",
+            "description": "Aufbau und Leitung des API Councils für einheitliche API-Standards und Developer Experience.",
+            "creator": { "@type": "Person", "name": "Thomas Schulze" },
+            "provider": { "@type": "Organization", "name": "SoftwareONE AG" },
+            "startDate": "2020-03-31",
+            "endDate": "2023-02-27"
+          }
+        }
+      ]
+    }
+  }
+  </script>
   <link rel="icon" type="image/svg+xml" href="img/logo-icon.svg" />
   <script>
     (function () {

--- a/projects.html
+++ b/projects.html
@@ -60,7 +60,7 @@
           "position": 3,
           "item": {
             "@type": "CreativeWork",
-            "name": "Development / Architecture of an Integration Platform",
+            "name": "Entwicklung/Architektur einer Integrationsplattform",
             "description": "Entwicklung und Architektur einer Integrationsplattform für die Kommunikation zwischen Domänen und Services.",
             "creator": { "@type": "Person", "name": "Thomas Schulze" },
             "provider": { "@type": "Organization", "name": "SoftwareONE AG" },
@@ -73,7 +73,7 @@
           "position": 4,
           "item": {
             "@type": "CreativeWork",
-            "name": "Co-Founder and Lead API Council",
+            "name": "Mitgründer und Lead API Council",
             "description": "Aufbau und Leitung des API Councils für einheitliche API-Standards und Developer Experience.",
             "creator": { "@type": "Person", "name": "Thomas Schulze" },
             "provider": { "@type": "Organization", "name": "SoftwareONE AG" },

--- a/tests/e2e/navigation.spec.js
+++ b/tests/e2e/navigation.spec.js
@@ -183,6 +183,45 @@ test.describe('SEO meta tags', () => {
     expect(ldJson['name']).toBe('Thomas Schulze');
     expect(ldJson['url']).toBe('https://thomas-schulze-it-solutions.de/');
   });
+
+  test('about.html has JSON-LD ProfilePage structured data', async ({ page }) => {
+    await page.goto('/about.html');
+    await page.waitForLoadState('domcontentloaded');
+    const ldJson = await page.evaluate(() => {
+      const el = document.querySelector('script[type="application/ld+json"]');
+      return el ? JSON.parse(el.textContent) : null;
+    });
+    expect(ldJson).not.toBeNull();
+    expect(ldJson['@type']).toBe('ProfilePage');
+    expect(ldJson.mainEntity['@type']).toBe('Person');
+    expect(ldJson.mainEntity.name).toBe('Thomas Schulze');
+  });
+
+  test('contact.html has JSON-LD ContactPage structured data', async ({ page }) => {
+    await page.goto('/contact.html');
+    await page.waitForLoadState('domcontentloaded');
+    const ldJson = await page.evaluate(() => {
+      const el = document.querySelector('script[type="application/ld+json"]');
+      return el ? JSON.parse(el.textContent) : null;
+    });
+    expect(ldJson).not.toBeNull();
+    expect(ldJson['@type']).toBe('ContactPage');
+    expect(ldJson.mainEntity['@type']).toBe('Organization');
+    expect(ldJson.mainEntity.name).toBe('Thomas Schulze IT Solutions');
+  });
+
+  test('projects.html has JSON-LD CollectionPage structured data', async ({ page }) => {
+    await page.goto('/projects.html');
+    await page.waitForLoadState('domcontentloaded');
+    const ldJson = await page.evaluate(() => {
+      const el = document.querySelector('script[type="application/ld+json"]');
+      return el ? JSON.parse(el.textContent) : null;
+    });
+    expect(ldJson).not.toBeNull();
+    expect(ldJson['@type']).toBe('CollectionPage');
+    expect(ldJson.mainEntity['@type']).toBe('ItemList');
+    expect(ldJson.mainEntity.itemListElement.length).toBeGreaterThanOrEqual(1);
+  });
 });
 
 test.describe('Custom 404 page', () => {


### PR DESCRIPTION
## Summary

Closes #37

Adds `<script type="application/ld+json">` structured data blocks to the three content pages that previously had none, improving how crawlers understand each page's purpose.

- **`about.html`** — `ProfilePage` wrapping a `Person` entity with `sameAs` social links, `knowsAbout` skills, and Leipzig address
- **`contact.html`** — `ContactPage` wrapping an `Organization` with `contactPoint`, `areaServed`, and available languages
- **`projects.html`** — `CollectionPage` wrapping an `ItemList` of the 4 most recent projects (static subset of `projectsData.de`); includes a maintenance comment to update when new projects are added via `/add-project`

All blocks are inserted in `<head>` after the `og:image` meta tag, matching the existing pattern in `index.html`. No JS, CSS, or other HTML files changed.

## Test plan

- [x] 3 new Playwright assertions added to the `SEO meta tags` describe block in `tests/e2e/navigation.spec.js`
- [x] All 486 tests pass locally (`486 passed`)
- [ ] CI Playwright suite passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)