### PR TITLE
a11y: add skip-to-main-content link (closes #34)

### DIFF
--- a/404.html
+++ b/404.html
@@ -26,7 +26,7 @@
 </head>
 <body>
 
-  <a href="#main-content" class="skip-link">Zum Inhalt springen</a>
+  <a href="#main-content" class="skip-link" data-i18n="a11y.skipToMain">Zum Inhalt springen</a>
 
   <nav class="navbar">
     <a href="index.html" class="navbar-brand"><img src="img/logo-icon.svg" alt="Thomas Schulze IT Solutions" /></a>
@@ -41,7 +41,7 @@
     </button>
   </nav>
 
-  <main id="main-content" class="page">
+  <main id="main-content" class="page" tabindex="-1">
     <div class="section">
       <div class="section-header" style="text-align: center;">
         <span class="section-label" data-i18n="notfound.label">Error 404</span>

--- a/404.html
+++ b/404.html
@@ -26,6 +26,8 @@
 </head>
 <body>
 
+  <a href="#main-content" class="skip-link">Zum Inhalt springen</a>
+
   <nav class="navbar">
     <a href="index.html" class="navbar-brand"><img src="img/logo-icon.svg" alt="Thomas Schulze IT Solutions" /></a>
     <ul class="nav-links">
@@ -39,7 +41,7 @@
     </button>
   </nav>
 
-  <main class="page">
+  <main id="main-content" class="page">
     <div class="section">
       <div class="section-header" style="text-align: center;">
         <span class="section-label" data-i18n="notfound.label">Error 404</span>

--- a/about.html
+++ b/about.html
@@ -59,6 +59,8 @@
 </head>
 <body>
 
+  <a href="#main-content" class="skip-link">Zum Inhalt springen</a>
+
   <!-- Navigation -->
   <nav class="navbar">
     <a href="index.html" class="navbar-brand"><img src="img/logo-icon.svg" alt="Thomas Schulze IT Solutions" /></a>
@@ -75,7 +77,7 @@
     </button>
   </nav>
 
-  <main class="page">
+  <main id="main-content" class="page">
     <div class="section">
       <div class="section-header">
         <span class="section-label" data-i18n="about.label">About Me</span>

--- a/about.html
+++ b/about.html
@@ -59,7 +59,7 @@
 </head>
 <body>
 
-  <a href="#main-content" class="skip-link">Zum Inhalt springen</a>
+  <a href="#main-content" class="skip-link" data-i18n="a11y.skipToMain">Zum Inhalt springen</a>
 
   <!-- Navigation -->
   <nav class="navbar">
@@ -77,7 +77,7 @@
     </button>
   </nav>
 
-  <main id="main-content" class="page">
+  <main id="main-content" class="page" tabindex="-1">
     <div class="section">
       <div class="section-header">
         <span class="section-label" data-i18n="about.label">About Me</span>

--- a/contact.html
+++ b/contact.html
@@ -56,6 +56,8 @@
 </head>
 <body>
 
+  <a href="#main-content" class="skip-link">Zum Inhalt springen</a>
+
   <!-- Navigation -->
   <nav class="navbar">
     <a href="index.html" class="navbar-brand"><img src="img/logo-icon.svg" alt="Thomas Schulze IT Solutions" /></a>
@@ -72,7 +74,7 @@
     </button>
   </nav>
 
-  <main class="page">
+  <main id="main-content" class="page">
     <div class="section">
       <div class="section-header">
         <span class="section-label" data-i18n="contact.label">Let's Talk</span>

--- a/contact.html
+++ b/contact.html
@@ -56,7 +56,7 @@
 </head>
 <body>
 
-  <a href="#main-content" class="skip-link">Zum Inhalt springen</a>
+  <a href="#main-content" class="skip-link" data-i18n="a11y.skipToMain">Zum Inhalt springen</a>
 
   <!-- Navigation -->
   <nav class="navbar">
@@ -74,7 +74,7 @@
     </button>
   </nav>
 
-  <main id="main-content" class="page">
+  <main id="main-content" class="page" tabindex="-1">
     <div class="section">
       <div class="section-header">
         <span class="section-label" data-i18n="contact.label">Let's Talk</span>

--- a/css/style.css
+++ b/css/style.css
@@ -1192,6 +1192,29 @@ html[data-theme="light"] .navbar-brand img {
   border: 0;
 }
 
+/* Skip to main content */
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 0;
+  z-index: 9999;
+  padding: 0.75rem 1.25rem;
+  background: var(--darker);
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 0.95rem;
+  border: 2px solid var(--accent);
+  border-radius: 0 0 var(--radius) 0;
+  text-decoration: none;
+  transition: top var(--transition);
+}
+
+.skip-link:focus {
+  top: 0;
+  outline: 3px solid var(--accent);
+  outline-offset: 2px;
+}
+
 /* ===== Responsive ===== */
 @media (max-width: 768px) {
   .hamburger {

--- a/css/style.css
+++ b/css/style.css
@@ -1209,7 +1209,7 @@ html[data-theme="light"] .navbar-brand img {
   transition: top var(--transition);
 }
 
-.skip-link:focus {
+.skip-link:focus-visible {
   top: 0;
   outline: 3px solid var(--accent);
   outline-offset: 2px;

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -25,6 +25,8 @@
 </head>
 <body>
 
+  <a href="#main-content" class="skip-link">Zum Inhalt springen</a>
+
   <!-- Navigation -->
   <nav class="navbar">
     <a href="index.html" class="navbar-brand"><img src="img/logo-icon.svg" alt="Thomas Schulze IT Solutions" /></a>
@@ -41,7 +43,7 @@
     </button>
   </nav>
 
-  <main class="page">
+  <main id="main-content" class="page">
     <div class="section">
       <div class="section-header">
         <span class="section-label">Legal</span>

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -43,7 +43,7 @@
     </button>
   </nav>
 
-  <main id="main-content" class="page">
+  <main id="main-content" class="page" tabindex="-1">
     <div class="section">
       <div class="section-header">
         <span class="section-label">Legal</span>

--- a/impressum.html
+++ b/impressum.html
@@ -25,6 +25,8 @@
 </head>
 <body>
 
+  <a href="#main-content" class="skip-link">Zum Inhalt springen</a>
+
   <!-- Navigation -->
   <nav class="navbar">
     <a href="index.html" class="navbar-brand"><img src="img/logo-icon.svg" alt="Thomas Schulze IT Solutions" /></a>
@@ -41,7 +43,7 @@
     </button>
   </nav>
 
-  <main class="page">
+  <main id="main-content" class="page">
     <div class="section">
       <div class="section-header">
         <span class="section-label">Legal</span>

--- a/impressum.html
+++ b/impressum.html
@@ -43,7 +43,7 @@
     </button>
   </nav>
 
-  <main id="main-content" class="page">
+  <main id="main-content" class="page" tabindex="-1">
     <div class="section">
       <div class="section-header">
         <span class="section-label">Legal</span>

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 </head>
 <body>
 
-  <a href="#main-content" class="skip-link">Zum Inhalt springen</a>
+  <a href="#main-content" class="skip-link" data-i18n="a11y.skipToMain">Zum Inhalt springen</a>
 
   <!-- Navigation -->
   <nav class="navbar">
@@ -59,7 +59,7 @@
   </nav>
 
   <!-- Hero -->
-  <main id="main-content" class="page">
+  <main id="main-content" class="page" tabindex="-1">
     <section class="hero">
       <div class="hero-content">
         <img src="img/logo.svg" alt="Thomas Schulze IT Solutions" class="hero-logo" />

--- a/index.html
+++ b/index.html
@@ -40,6 +40,8 @@
 </head>
 <body>
 
+  <a href="#main-content" class="skip-link">Zum Inhalt springen</a>
+
   <!-- Navigation -->
   <nav class="navbar">
     <a href="index.html" class="navbar-brand"><img src="img/logo-icon.svg" alt="Thomas Schulze IT Solutions" /></a>
@@ -57,7 +59,7 @@
   </nav>
 
   <!-- Hero -->
-  <main class="page">
+  <main id="main-content" class="page">
     <section class="hero">
       <div class="hero-content">
         <img src="img/logo.svg" alt="Thomas Schulze IT Solutions" class="hero-logo" />

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -129,6 +129,9 @@
       'notfound.desc':     'The page you are looking for does not exist or has been moved.',
       'notfound.btn':      '← Back to Home',
 
+      /* --- Accessibility --- */
+      'a11y.skipToMain': 'Skip to main content',
+
       /* --- Footer --- */
       'footer.contact':     'Contact',
       'footer.impressum':   'Impressum',
@@ -247,6 +250,9 @@
       'notfound.title':    'Seite nicht gefunden',
       'notfound.desc':     'Die gesuchte Seite existiert nicht oder wurde verschoben.',
       'notfound.btn':      '← Zurück zur Startseite',
+
+      /* --- Accessibility --- */
+      'a11y.skipToMain': 'Zum Inhalt springen',
 
       /* --- Footer --- */
       'footer.contact':     'Kontakt',

--- a/projects.html
+++ b/projects.html
@@ -97,6 +97,8 @@
 </head>
 <body>
 
+  <a href="#main-content" class="skip-link">Zum Inhalt springen</a>
+
   <!-- Navigation -->
   <nav class="navbar">
     <a href="index.html" class="navbar-brand"><img src="img/logo-icon.svg" alt="Thomas Schulze IT Solutions" /></a>
@@ -113,7 +115,7 @@
     </button>
   </nav>
 
-  <main class="page">
+  <main id="main-content" class="page">
     <div class="section">
       <div class="section-header">
         <span class="section-label" data-i18n="projects.label">Portfolio</span>

--- a/projects.html
+++ b/projects.html
@@ -97,7 +97,7 @@
 </head>
 <body>
 
-  <a href="#main-content" class="skip-link">Zum Inhalt springen</a>
+  <a href="#main-content" class="skip-link" data-i18n="a11y.skipToMain">Zum Inhalt springen</a>
 
   <!-- Navigation -->
   <nav class="navbar">
@@ -115,7 +115,7 @@
     </button>
   </nav>
 
-  <main id="main-content" class="page">
+  <main id="main-content" class="page" tabindex="-1">
     <div class="section">
       <div class="section-header">
         <span class="section-label" data-i18n="projects.label">Portfolio</span>

--- a/tests/e2e/accessibility.spec.js
+++ b/tests/e2e/accessibility.spec.js
@@ -61,5 +61,17 @@ test.describe('Skip-to-main-content link', () => {
 
       await expect(page.locator('main#main-content')).toBeAttached();
     });
+
+    test(`${path} – activating skip link moves focus to main`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState('domcontentloaded');
+
+      await page.keyboard.press('Tab');
+      await expect(page.locator('.skip-link')).toBeFocused();
+      await page.keyboard.press('Enter');
+
+      const focusedId = await page.evaluate(() => document.activeElement?.id ?? null);
+      expect(focusedId).toBe('main-content');
+    });
   }
 });

--- a/tests/e2e/accessibility.spec.js
+++ b/tests/e2e/accessibility.spec.js
@@ -1,0 +1,65 @@
+// @ts-check
+/**
+ * Accessibility tests – skip-to-main-content link (issue #34).
+ *
+ * Verifies that every page exposes a visible skip link as the first focusable
+ * element, and that the target anchor (#main-content) exists on <main>.
+ */
+const { test, expect } = require('@playwright/test');
+
+const ALL_PAGES = [
+  '/index.html',
+  '/about.html',
+  '/projects.html',
+  '/contact.html',
+  '/impressum.html',
+  '/datenschutz.html',
+  '/404.html',
+];
+
+test.describe('Skip-to-main-content link', () => {
+  for (const path of ALL_PAGES) {
+    test(`${path} – skip link present and href correct`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState('domcontentloaded');
+
+      const skipLink = page.locator('.skip-link');
+      await expect(skipLink).toBeAttached();
+      await expect(skipLink).toHaveAttribute('href', '#main-content');
+    });
+
+    test(`${path} – skip link is first focusable element`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState('domcontentloaded');
+
+      await page.keyboard.press('Tab');
+      const focusedHref = await page.evaluate(() => {
+        const el = document.activeElement;
+        return el ? el.getAttribute('href') : null;
+      });
+      expect(focusedHref).toBe('#main-content');
+    });
+
+    test(`${path} – skip link hidden before focus, visible after`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState('domcontentloaded');
+
+      const skipLink = page.locator('.skip-link');
+
+      // Before focus: element is above the viewport (top: -100%)
+      await expect(skipLink).not.toBeInViewport();
+
+      // After Tab: link receives focus and scrolls into view (top: 0)
+      await page.keyboard.press('Tab');
+      await expect(skipLink).toBeFocused();
+      await expect(skipLink).toBeInViewport();
+    });
+
+    test(`${path} – main has id="main-content"`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState('domcontentloaded');
+
+      await expect(page.locator('main#main-content')).toBeAttached();
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Adds a visually hidden `.skip-link` as the first focusable element on all 7 pages (`index`, `about`, `projects`, `contact`, `impressum`, `datenschutz`, `404`)
- Link becomes visible on keyboard focus (top-left, amber `--accent` colour, `z-index: 9999` above fixed nav)
- Adds `id="main-content"` to every `<main>` element as the skip target
- CSS uses only existing custom properties (`--darker`, `--accent`, `--radius`, `--transition`); new styles added in the existing Accessibility utilities section of `css/style.css`
- New `tests/e2e/accessibility.spec.js` with 56 tests (4 assertions × 7 pages × 2 browsers)

## Test plan

- [ ] Run `npx playwright test e2e/accessibility.spec.js` — all 56 tests pass
- [ ] Run full suite `npx playwright test` — all 542 tests pass
- [ ] Manual: open any page, press Tab once — skip link appears top-left in amber; press Enter — viewport jumps to `<main>`
- [ ] Manual: verify skip link is invisible on mouse-only navigation (no layout shift)

## Screenshots

> Before/after screenshots required per project convention — please add them to this PR before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)