### PR TITLE
fix: reduce test output noise

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd tests && npx playwright test",
+            "command": "cd tests && npx playwright test --reporter=dot",
             "timeout": 120,
             "statusMessage": "Running Playwright tests..."
           }

--- a/tests/playwright.config.js
+++ b/tests/playwright.config.js
@@ -16,7 +16,7 @@ module.exports = defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 2 : undefined,
-  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'line',
 
   use: {
     baseURL: 'http://localhost:3000',
@@ -40,5 +40,7 @@ module.exports = defineConfig({
     cwd: '..',
     port: 3000,
     reuseExistingServer: !process.env.CI,
+    stdout: 'ignore',
+    stderr: 'ignore'
   },
 });

--- a/tests/playwright.config.js
+++ b/tests/playwright.config.js
@@ -41,6 +41,6 @@ module.exports = defineConfig({
     port: 3000,
     reuseExistingServer: !process.env.CI,
     stdout: 'ignore',
-    stderr: 'ignore'
+    stderr: 'ignore',
   },
 });


### PR DESCRIPTION
## Summary

- WebServer `stdout`/`stderr` von `pipe` auf `ignore` gesetzt — Python HTTP Server Ausgabe wird komplett unterdrückt
- Post-Commit Hook nutzt jetzt `--reporter=dot` statt des Standard-`line`-Reporters
- Manuelle Testläufe (`npx playwright test`) bleiben auf `line`-Reporter

🤖 Generated with [Claude Code](https://claude.com/claude-code)