### PR TITLE
feat: add hreflang tags for SEO language targeting

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,6 +6,8 @@
   <title>Über mich – Thomas Schulze IT Solutions</title>
   <meta name="description" content="Erfahren Sie mehr über Thomas Schulze, freiberuflicher Software-Ingenieur mit Spezialisierung auf .NET, C#, Angular, React und Cloud-Technologien." />
   <link rel="canonical" href="https://thomas-schulze-it-solutions.de/about.html" />
+  <link rel="alternate" hreflang="de" href="https://thomas-schulze-it-solutions.de/about.html" />
+  <link rel="alternate" hreflang="x-default" href="https://thomas-schulze-it-solutions.de/about.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://thomas-schulze-it-solutions.de/about.html" />
   <meta property="og:title" content="Über mich – Thomas Schulze IT Solutions" />

--- a/contact.html
+++ b/contact.html
@@ -6,6 +6,8 @@
   <title>Kontakt – Thomas Schulze IT Solutions</title>
   <meta name="description" content="Nehmen Sie Kontakt mit Thomas Schulze auf – freiberuflicher Software-Ingenieur. Verfügbar für neue Projekte, Beratung und Teamerweiterung." />
   <link rel="canonical" href="https://thomas-schulze-it-solutions.de/contact.html" />
+  <link rel="alternate" hreflang="de" href="https://thomas-schulze-it-solutions.de/contact.html" />
+  <link rel="alternate" hreflang="x-default" href="https://thomas-schulze-it-solutions.de/contact.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://thomas-schulze-it-solutions.de/contact.html" />
   <meta property="og:title" content="Kontakt – Thomas Schulze IT Solutions" />

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -6,6 +6,7 @@
   <title>Datenschutz – Thomas Schulze IT Solutions</title>
   <meta name="description" content="Datenschutzerklärung für Thomas Schulze IT Solutions gemäß DSGVO." />
   <link rel="canonical" href="https://thomas-schulze-it-solutions.de/datenschutz.html" />
+  <link rel="alternate" hreflang="de" href="https://thomas-schulze-it-solutions.de/datenschutz.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://thomas-schulze-it-solutions.de/datenschutz.html" />
   <meta property="og:title" content="Datenschutz – Thomas Schulze IT Solutions" />

--- a/impressum.html
+++ b/impressum.html
@@ -6,6 +6,7 @@
   <title>Impressum – Thomas Schulze IT Solutions</title>
   <meta name="description" content="Impressum und rechtliche Hinweise für Thomas Schulze IT Solutions." />
   <link rel="canonical" href="https://thomas-schulze-it-solutions.de/impressum.html" />
+  <link rel="alternate" hreflang="de" href="https://thomas-schulze-it-solutions.de/impressum.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://thomas-schulze-it-solutions.de/impressum.html" />
   <meta property="og:title" content="Impressum – Thomas Schulze IT Solutions" />

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <title>Thomas Schulze – Softwarearchitekt &amp; .NET-Freelancer</title>
   <meta name="description" content="Freiberuflicher Softwarearchitekt und .NET-Entwickler aus Leipzig. Spezialisiert auf Microservices, Cloud-Architektur, DevOps und moderne Softwareentwicklung." />
   <link rel="canonical" href="https://thomas-schulze-it-solutions.de/" />
+  <link rel="alternate" hreflang="de" href="https://thomas-schulze-it-solutions.de/" />
+  <link rel="alternate" hreflang="x-default" href="https://thomas-schulze-it-solutions.de/" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://thomas-schulze-it-solutions.de/" />
   <meta property="og:title" content="Thomas Schulze – Softwarearchitekt &amp; .NET-Freelancer" />

--- a/projects.html
+++ b/projects.html
@@ -6,6 +6,8 @@
   <title>Projekte – Thomas Schulze IT Solutions</title>
   <meta name="description" content="Eine Auswahl an Projekten von Thomas Schulze – freiberuflicher Software-Ingenieur mit Spezialisierung auf .NET, C#, Angular, React und Cloud-Lösungen." />
   <link rel="canonical" href="https://thomas-schulze-it-solutions.de/projects.html" />
+  <link rel="alternate" hreflang="de" href="https://thomas-schulze-it-solutions.de/projects.html" />
+  <link rel="alternate" hreflang="x-default" href="https://thomas-schulze-it-solutions.de/projects.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://thomas-schulze-it-solutions.de/projects.html" />
   <meta property="og:title" content="Projekte – Thomas Schulze IT Solutions" />

--- a/tests/e2e/navigation.spec.js
+++ b/tests/e2e/navigation.spec.js
@@ -291,40 +291,42 @@ test.describe('Custom 404 page', () => {
 });
 
 test.describe('hreflang tags', () => {
-  const i18nPages = [
-    { path: '/index.html',    url: 'https://thomas-schulze-it-solutions.de/' },
-    { path: '/about.html',    url: 'https://thomas-schulze-it-solutions.de/about.html' },
-    { path: '/projects.html', url: 'https://thomas-schulze-it-solutions.de/projects.html' },
-    { path: '/contact.html',  url: 'https://thomas-schulze-it-solutions.de/contact.html' },
-  ];
+  // Pages with i18n toggles (DE/EN) should expose both `de` and `x-default` hreflang links
+  const i18nPages = pages.filter(p =>
+    p.path === '/index.html' ||
+    p.path === '/about.html' ||
+    p.path === '/projects.html' ||
+    p.path === '/contact.html'
+  );
 
-  for (const { path, url } of i18nPages) {
+  for (const { path, canonical } of i18nPages) {
     test(`${path} has hreflang="de" pointing to canonical URL`, async ({ page }) => {
       await page.goto(path);
       await page.waitForLoadState('domcontentloaded');
       const href = await page.locator('link[rel="alternate"][hreflang="de"]').getAttribute('href');
-      expect(href).toBe(url);
+      expect(href).toBe(canonical);
     });
 
     test(`${path} has hreflang="x-default" pointing to canonical URL`, async ({ page }) => {
       await page.goto(path);
       await page.waitForLoadState('domcontentloaded');
       const href = await page.locator('link[rel="alternate"][hreflang="x-default"]').getAttribute('href');
-      expect(href).toBe(url);
+      expect(href).toBe(canonical);
     });
   }
 
-  const legalPages = [
-    { path: '/impressum.html',   url: 'https://thomas-schulze-it-solutions.de/impressum.html' },
-    { path: '/datenschutz.html', url: 'https://thomas-schulze-it-solutions.de/datenschutz.html' },
-  ];
+  // German-only legal pages should only expose `de` hreflang (no `x-default`)
+  const legalPages = pages.filter(p =>
+    p.path === '/impressum.html' ||
+    p.path === '/datenschutz.html'
+  );
 
-  for (const { path, url } of legalPages) {
+  for (const { path, canonical } of legalPages) {
     test(`${path} has hreflang="de" pointing to canonical URL`, async ({ page }) => {
       await page.goto(path);
       await page.waitForLoadState('domcontentloaded');
       const href = await page.locator('link[rel="alternate"][hreflang="de"]').getAttribute('href');
-      expect(href).toBe(url);
+      expect(href).toBe(canonical);
     });
 
     test(`${path} does NOT have hreflang="x-default"`, async ({ page }) => {

--- a/tests/e2e/navigation.spec.js
+++ b/tests/e2e/navigation.spec.js
@@ -290,6 +290,52 @@ test.describe('Custom 404 page', () => {
   });
 });
 
+test.describe('hreflang tags', () => {
+  const i18nPages = [
+    { path: '/index.html',    url: 'https://thomas-schulze-it-solutions.de/' },
+    { path: '/about.html',    url: 'https://thomas-schulze-it-solutions.de/about.html' },
+    { path: '/projects.html', url: 'https://thomas-schulze-it-solutions.de/projects.html' },
+    { path: '/contact.html',  url: 'https://thomas-schulze-it-solutions.de/contact.html' },
+  ];
+
+  for (const { path, url } of i18nPages) {
+    test(`${path} has hreflang="de" pointing to canonical URL`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState('domcontentloaded');
+      const href = await page.locator('link[rel="alternate"][hreflang="de"]').getAttribute('href');
+      expect(href).toBe(url);
+    });
+
+    test(`${path} has hreflang="x-default" pointing to canonical URL`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState('domcontentloaded');
+      const href = await page.locator('link[rel="alternate"][hreflang="x-default"]').getAttribute('href');
+      expect(href).toBe(url);
+    });
+  }
+
+  const legalPages = [
+    { path: '/impressum.html',   url: 'https://thomas-schulze-it-solutions.de/impressum.html' },
+    { path: '/datenschutz.html', url: 'https://thomas-schulze-it-solutions.de/datenschutz.html' },
+  ];
+
+  for (const { path, url } of legalPages) {
+    test(`${path} has hreflang="de" pointing to canonical URL`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState('domcontentloaded');
+      const href = await page.locator('link[rel="alternate"][hreflang="de"]').getAttribute('href');
+      expect(href).toBe(url);
+    });
+
+    test(`${path} does NOT have hreflang="x-default"`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState('domcontentloaded');
+      const count = await page.locator('link[rel="alternate"][hreflang="x-default"]').count();
+      expect(count).toBe(0);
+    });
+  }
+});
+
 test.describe('SEO crawl files', () => {
   test('robots.txt is served and disallows dev/tooling paths', async ({ request }) => {
     const response = await request.get('/robots.txt');


### PR DESCRIPTION
Closes #35

## Summary

- Added `hreflang="de"` + `hreflang="x-default"` to all 4 i18n pages (`index`, `about`, `projects`, `contact`), both pointing to the existing canonical URL
- Added `hreflang="de"` only to `impressum.html` and `datenschutz.html` (German-only legal pages — no `x-default` intentionally)
- Added 12 new Playwright tests in `navigation.spec.js`, including negative assertions that legal pages must NOT have `hreflang="x-default"`

## Why this approach

Since the site has no separate `/en/` URLs (language toggle is client-side JS only), adding `hreflang="en"` pointing to the same URL would create a malformed hreflang cluster that Google flags as conflicting annotations. The correct signal for a German-primary site with a JS overlay is `hreflang="de"` + `hreflang="x-default"` on the same URL.

## Test plan

- [x] All 170 Playwright tests pass (`npx playwright test e2e/navigation.spec.js`)
- [x] 12 new hreflang tests added (8 for i18n pages × 2 attributes, 4 for legal pages including negative x-default assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)