### PR TITLE
refactor: extract inline styles to CSS + preload Arimo fonts (#72)

### DIFF
--- a/404.html
+++ b/404.html
@@ -25,6 +25,8 @@
       document.documentElement.setAttribute('data-theme', t);
     })();
   </script>
+  <link rel="preload" href="fonts/arimo-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="fonts/arimo-latin-700-normal.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>

--- a/404.html
+++ b/404.html
@@ -46,12 +46,12 @@
 
   <main id="main-content" class="page" tabindex="-1">
     <div class="section">
-      <div class="section-header" style="text-align: center;">
+      <div class="section-header">
         <span class="section-label" data-i18n="notfound.label">Error 404</span>
-        <div style="font-size: 6rem; margin: 1rem 0;" aria-hidden="true">🔍</div>
+        <div class="notfound-emoji" aria-hidden="true">🔍</div>
         <h1 class="section-title" data-i18n="notfound.title">Page not found</h1>
         <p class="section-desc" data-i18n="notfound.desc">The page you are looking for does not exist or has been moved.</p>
-        <div style="margin-top: 2rem;">
+        <div class="notfound-cta">
           <a href="index.html" class="btn btn-primary" data-i18n="notfound.btn">← Back to Home</a>
         </div>
       </div>

--- a/about.html
+++ b/about.html
@@ -64,6 +64,8 @@
       document.documentElement.setAttribute('data-theme', t);
     })();
   </script>
+  <link rel="preload" href="fonts/arimo-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="fonts/arimo-latin-700-normal.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>

--- a/about.html
+++ b/about.html
@@ -99,7 +99,7 @@
         <aside class="about-avatar-wrapper">
           <div class="avatar-photo-wrapper">
             <img src="img/thomas-schulze.jpg" alt="Thomas Schulze" class="avatar-photo" onerror="this.style.display='none';this.nextElementSibling.style.display='flex';" />
-            <div class="avatar-circle avatar-fallback" style="display:none;">TS</div>
+            <div class="avatar-circle avatar-fallback">TS</div>
           </div>
           <p class="about-name">Thomas Schulze</p>
           <p class="about-role" data-i18n="about.role">Freelance Software Engineer</p>
@@ -129,8 +129,8 @@
             </a>
           </div>
 
-          <div style="margin-top: 1.5rem;">
-            <a href="contact.html" class="btn btn-primary" style="width: 100%; justify-content: center;" data-i18n="about.hire">Hire Me</a>
+          <div class="about-cta">
+            <a href="contact.html" class="btn btn-primary btn-block" data-i18n="about.hire">Hire Me</a>
           </div>
         </aside>
 
@@ -167,7 +167,7 @@
             </div>
           </div>
 
-          <h2 style="margin-top: 2.5rem;" data-i18n="about.skills.title">Technical Skills</h2>
+          <h2 class="about-content-heading" data-i18n="about.skills.title">Technical Skills</h2>
           <p data-i18n="about.skills.desc">Technologies and tools I work with:</p>
 
           <div class="skills-grid">
@@ -188,9 +188,9 @@
             <div class="skill-chip"><span class="skill-dot"></span>Agile / Scrum</div>
           </div>
 
-          <h2 style="margin-top: 2.5rem;" data-i18n="about.offer.title">What I Offer</h2>
+          <h2 class="about-content-heading" data-i18n="about.offer.title">What I Offer</h2>
           <p data-i18n="about.offer.desc">As a freelancer I offer end-to-end software development services:</p>
-          <ul style="color: var(--text-muted); line-height: 2; padding-left: 1.5rem; margin-top: 0.5rem;" data-i18n-html="about.offer.list">
+          <ul class="offer-list" data-i18n-html="about.offer.list">
             <li>Custom web application development (frontend &amp; backend)</li>
             <li>REST API &amp; microservice architecture design and implementation</li>
             <li>Legacy system modernisation and refactoring</li>

--- a/contact.html
+++ b/contact.html
@@ -120,9 +120,9 @@
               </div>
             </div>
 
-            <a href="https://www.linkedin.com/in/thomas-schulze-it-solutions" class="contact-item" target="_blank" rel="noopener" style="text-decoration:none;">
+            <a href="https://www.linkedin.com/in/thomas-schulze-it-solutions" class="contact-item" target="_blank" rel="noopener">
               <div class="contact-item-icon">
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" style="color:#0a66c2;" aria-hidden="true">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" class="icon-linkedin" aria-hidden="true">
                   <path d="M19 3a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h14zm-.5 15.5v-5.3a3.26 3.26 0 00-3.26-3.26c-.85 0-1.84.52-2.32 1.3v-1.11h-2.79v8.37h2.79v-4.93c0-.77.62-1.4 1.39-1.4a1.4 1.4 0 011.4 1.4v4.93h2.79zM6.88 8.56a1.68 1.68 0 001.68-1.68c0-.93-.75-1.69-1.68-1.69a1.69 1.69 0 00-1.69 1.69c0 .93.76 1.68 1.69 1.68zm1.39 9.94v-8.37H5.5v8.37h2.77z"/>
                 </svg>
               </div>
@@ -132,9 +132,9 @@
               </div>
             </a>
 
-            <a href="https://www.freelancermap.de/profil/thomas-schulze-257276" class="contact-item" target="_blank" rel="noopener" style="text-decoration:none;">
+            <a href="https://www.freelancermap.de/profil/thomas-schulze-257276" class="contact-item" target="_blank" rel="noopener">
               <div class="contact-item-icon">
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--accent);" aria-hidden="true">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon-accent" aria-hidden="true">
                   <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
                   <circle cx="12" cy="7" r="4"/>
                 </svg>
@@ -146,9 +146,9 @@
             </a>
           </div>
 
-          <div style="margin-top: 2rem; padding: 1.25rem; background: rgba(0,212,255,0.06); border: 1px solid rgba(0,212,255,0.2); border-radius: var(--radius);">
-            <strong style="color: var(--accent); font-size: 0.85rem; display: block; margin-bottom: 0.4rem;" data-i18n="contact.available">&#x2705; Currently Available</strong>
-            <span style="color: var(--text-muted); font-size: 0.9rem;" data-i18n="contact.available.text">I'm open to new freelance engagements. Let's talk about your project!</span>
+          <div class="availability-note">
+            <strong data-i18n="contact.available">&#x2705; Currently Available</strong>
+            <span data-i18n="contact.available.text">I'm open to new freelance engagements. Let's talk about your project!</span>
           </div>
         </div>
 
@@ -191,7 +191,7 @@
                 placeholder="Tell me about your project or question…"></textarea>
             </div>
 
-            <button type="submit" class="btn btn-primary" style="width:100%; justify-content:center;" data-i18n="contact.form.submit">
+            <button type="submit" class="btn btn-primary btn-block" data-i18n="contact.form.submit">
               Send Message &#x2192;
             </button>
           </form>

--- a/contact.html
+++ b/contact.html
@@ -61,6 +61,8 @@
       document.documentElement.setAttribute('data-theme', t);
     })();
   </script>
+  <link rel="preload" href="fonts/arimo-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="fonts/arimo-latin-700-normal.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>

--- a/css/style.css
+++ b/css/style.css
@@ -62,6 +62,9 @@
   --radius: 12px;
   --shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
   --transition: 0.3s ease;
+  --color-linkedin: #0a66c2;
+  --available-bg: rgba(0, 212, 255, 0.06);
+  --available-border: rgba(0, 212, 255, 0.2);
   /* Theme-sensitive surface colours (overridden in light mode) */
   --navbar-bg: rgba(16, 14, 8, 0.92);
   --dot-color: rgba(255, 255, 255, 0.04);
@@ -410,6 +413,12 @@ img {
   color: var(--dark);
   box-shadow: 0 0 40px rgba(255, 194, 80, 0.25);
   letter-spacing: 0.05em;
+}
+
+/* Hidden until the avatar photo fails to load; the img onerror sets
+   inline display:flex, which overrides this rule. */
+.avatar-fallback {
+  display: none;
 }
 
 .about-name {
@@ -797,6 +806,7 @@ img {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   transition: all var(--transition);
+  text-decoration: none;
 }
 
 .contact-item:hover {
@@ -1213,6 +1223,115 @@ html[data-theme="light"] .navbar-brand img {
   top: 0;
   outline: 3px solid var(--accent);
   outline-offset: 2px;
+}
+
+/* ===== Value Propositions (index) ===== */
+.value-props {
+  padding: 3rem 2rem;
+  background: var(--darker);
+}
+
+.value-props-grid {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.value-prop {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.value-prop-icon {
+  font-size: 1.8rem;
+}
+
+.value-prop-title {
+  color: var(--white);
+  display: block;
+  margin-bottom: 0.3rem;
+}
+
+.value-prop-text {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+/* ===== Availability note (contact) ===== */
+.availability-note {
+  margin-top: 2rem;
+  padding: 1.25rem;
+  background: var(--available-bg);
+  border: 1px solid var(--available-border);
+  border-radius: var(--radius);
+}
+
+.availability-note strong {
+  color: var(--accent);
+  font-size: 0.85rem;
+  display: block;
+  margin-bottom: 0.4rem;
+}
+
+.availability-note span {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+/* ===== Brand / accent icon colours ===== */
+.icon-linkedin {
+  color: var(--color-linkedin);
+}
+
+.icon-accent {
+  color: var(--accent);
+}
+
+/* ===== Layout helpers ===== */
+.btn-block {
+  width: 100%;
+  justify-content: center;
+}
+
+.about-cta {
+  margin-top: 1.5rem;
+}
+
+.about-content-heading {
+  margin-top: 2.5rem;
+}
+
+.offer-list {
+  color: var(--text-muted);
+  line-height: 2;
+  padding-left: 1.5rem;
+  margin-top: 0.5rem;
+}
+
+.projects-cta {
+  text-align: center;
+  margin-top: 3.5rem;
+}
+
+.projects-cta-text {
+  color: var(--text-muted);
+  margin-bottom: 1.25rem;
+}
+
+.notfound-emoji {
+  font-size: 6rem;
+  margin: 1rem 0;
+}
+
+.notfound-cta {
+  margin-top: 2rem;
 }
 
 /* ===== Responsive ===== */

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -29,6 +29,8 @@
       document.documentElement.setAttribute('data-theme', t);
     })();
   </script>
+  <link rel="preload" href="fonts/arimo-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="fonts/arimo-latin-700-normal.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>

--- a/impressum.html
+++ b/impressum.html
@@ -29,6 +29,8 @@
       document.documentElement.setAttribute('data-theme', t);
     })();
   </script>
+  <link rel="preload" href="fonts/arimo-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="fonts/arimo-latin-700-normal.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -138,38 +138,38 @@
     </section>
 
     <!-- Quick value props -->
-    <section style="padding: 3rem 2rem; background: var(--darker);">
-      <div style="max-width: 1100px; margin: 0 auto; display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1.5rem;">
+    <section class="value-props">
+      <div class="value-props-grid">
 
-        <div style="display:flex; align-items:flex-start; gap:1rem; padding: 1.5rem; background: var(--card-bg); border: 1px solid var(--border); border-radius: var(--radius);">
-          <span style="font-size:1.8rem;">&#x1F3AF;</span>
+        <div class="value-prop">
+          <span class="value-prop-icon">&#x1F3AF;</span>
           <div>
-            <strong style="color:var(--white); display:block; margin-bottom:.3rem;" data-i18n="index.prop1.title">Goal-Oriented</strong>
-            <span style="color:var(--text-muted); font-size:.9rem;" data-i18n="index.prop1.text">I focus on delivering value, not just code. Your business goals drive every technical decision.</span>
+            <strong class="value-prop-title" data-i18n="index.prop1.title">Goal-Oriented</strong>
+            <span class="value-prop-text" data-i18n="index.prop1.text">I focus on delivering value, not just code. Your business goals drive every technical decision.</span>
           </div>
         </div>
 
-        <div style="display:flex; align-items:flex-start; gap:1rem; padding: 1.5rem; background: var(--card-bg); border: 1px solid var(--border); border-radius: var(--radius);">
-          <span style="font-size:1.8rem;">&#x1F50D;</span>
+        <div class="value-prop">
+          <span class="value-prop-icon">&#x1F50D;</span>
           <div>
-            <strong style="color:var(--white); display:block; margin-bottom:.3rem;" data-i18n="index.prop2.title">Clean Code</strong>
-            <span style="color:var(--text-muted); font-size:.9rem;" data-i18n="index.prop2.text">Readable, maintainable, and well-tested software that your team can build on confidently.</span>
+            <strong class="value-prop-title" data-i18n="index.prop2.title">Clean Code</strong>
+            <span class="value-prop-text" data-i18n="index.prop2.text">Readable, maintainable, and well-tested software that your team can build on confidently.</span>
           </div>
         </div>
 
-        <div style="display:flex; align-items:flex-start; gap:1rem; padding: 1.5rem; background: var(--card-bg); border: 1px solid var(--border); border-radius: var(--radius);">
-          <span style="font-size:1.8rem;">&#x1F4AC;</span>
+        <div class="value-prop">
+          <span class="value-prop-icon">&#x1F4AC;</span>
           <div>
-            <strong style="color:var(--white); display:block; margin-bottom:.3rem;" data-i18n="index.prop3.title">Clear Communication</strong>
-            <span style="color:var(--text-muted); font-size:.9rem;" data-i18n="index.prop3.text">Regular updates, transparent progress, and plain-language explanations throughout the project.</span>
+            <strong class="value-prop-title" data-i18n="index.prop3.title">Clear Communication</strong>
+            <span class="value-prop-text" data-i18n="index.prop3.text">Regular updates, transparent progress, and plain-language explanations throughout the project.</span>
           </div>
         </div>
 
-        <div style="display:flex; align-items:flex-start; gap:1rem; padding: 1.5rem; background: var(--card-bg); border: 1px solid var(--border); border-radius: var(--radius);">
-          <span style="font-size:1.8rem;">&#x23F1;&#xFE0F;</span>
+        <div class="value-prop">
+          <span class="value-prop-icon">&#x23F1;&#xFE0F;</span>
           <div>
-            <strong style="color:var(--white); display:block; margin-bottom:.3rem;" data-i18n="index.prop4.title">On-Time Delivery</strong>
-            <span style="color:var(--text-muted); font-size:.9rem;" data-i18n="index.prop4.text">Structured planning and agile iterations to keep your project on schedule and within budget.</span>
+            <strong class="value-prop-title" data-i18n="index.prop4.title">On-Time Delivery</strong>
+            <span class="value-prop-text" data-i18n="index.prop4.text">Structured planning and agile iterations to keep your project on schedule and within budget.</span>
           </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -79,6 +79,8 @@
       document.documentElement.setAttribute('data-theme', t);
     })();
   </script>
+  <link rel="preload" href="fonts/arimo-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="fonts/arimo-latin-700-normal.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>

--- a/projects.html
+++ b/projects.html
@@ -102,6 +102,8 @@
       document.documentElement.setAttribute('data-theme', t);
     })();
   </script>
+  <link rel="preload" href="fonts/arimo-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="fonts/arimo-latin-700-normal.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>

--- a/projects.html
+++ b/projects.html
@@ -142,8 +142,8 @@
       <div class="projects-grid" id="projectsGrid"></div>
 
       <!-- CTA -->
-      <div style="text-align: center; margin-top: 3.5rem;">
-        <p style="color: var(--text-muted); margin-bottom: 1.25rem;" data-i18n="projects.cta.text">
+      <div class="projects-cta">
+        <p class="projects-cta-text" data-i18n="projects.cta.text">
           Have a project in mind? Let's build something great together.
         </p>
         <a href="contact.html" class="btn btn-primary" data-i18n="projects.cta.btn">Get in Touch →</a>

--- a/tests/e2e/fonts.spec.js
+++ b/tests/e2e/fonts.spec.js
@@ -106,3 +106,33 @@ test.describe('Removed latin-ext font files are not served', () => {
     });
   }
 });
+
+test.describe('Arimo fonts are preloaded', () => {
+  // Every page preloads the two non-italic Arimo weights to cut the
+  // first-visit FOUT. Italic variants must NOT be preloaded.
+  const ALL_PAGES = [...PAGES, '/404.html'];
+
+  for (const path of ALL_PAGES) {
+    test(`${path} preloads the 400 + 700 normal weights`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState('domcontentloaded');
+
+      for (const weight of ['400', '700']) {
+        const link = page.locator(
+          `link[rel="preload"][as="font"][href="fonts/arimo-latin-${weight}-normal.woff2"]`
+        );
+        await expect(link).toHaveCount(1);
+        await expect(link).toHaveAttribute('type', 'font/woff2');
+        // crossorigin is required for preloaded fonts to be reused.
+        await expect(link).toHaveAttribute('crossorigin', '');
+      }
+    });
+
+    test(`${path} does not preload italic weights`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState('domcontentloaded');
+      const italicPreloads = page.locator('link[rel="preload"][as="font"][href*="italic"]');
+      await expect(italicPreloads).toHaveCount(0);
+    });
+  }
+});

--- a/tests/e2e/fonts.spec.js
+++ b/tests/e2e/fonts.spec.js
@@ -123,8 +123,9 @@ test.describe('Arimo fonts are preloaded', () => {
         );
         await expect(link).toHaveCount(1);
         await expect(link).toHaveAttribute('type', 'font/woff2');
-        // crossorigin is required for preloaded fonts to be reused.
-        await expect(link).toHaveAttribute('crossorigin', '');
+        // crossorigin is required for preloaded fonts to be reused. Accept the
+        // boolean form ("") or the explicit "anonymous"; reject use-credentials.
+        await expect(link).toHaveAttribute('crossorigin', /^(anonymous)?$/);
       }
     });
 

--- a/tests/e2e/navigation.spec.js
+++ b/tests/e2e/navigation.spec.js
@@ -512,7 +512,9 @@ test.describe('No inline styles (AD-2)', () => {
       const response = await request.get(path);
       expect(response.status()).toBe(200);
       const body = await response.text();
-      expect(body, `${path} must not contain an inline style="" attribute`).not.toMatch(/\sstyle\s*=/);
+      // Case-insensitive: HTML attribute names are case-insensitive, so
+      // STYLE= / mixed-case must be caught too.
+      expect(body, `${path} must not contain an inline style="" attribute`).not.toMatch(/\sstyle\s*=/i);
     });
   }
 });

--- a/tests/e2e/navigation.spec.js
+++ b/tests/e2e/navigation.spec.js
@@ -490,3 +490,29 @@ test.describe('SEO crawl files', () => {
     });
   }
 });
+
+test.describe('No inline styles (AD-2)', () => {
+  // All styling lives in css/style.css — no page may carry a style="..."
+  // attribute. Checked against the raw HTML source so runtime JS that sets
+  // element.style (hamburger, accordion, form) can't cause false positives.
+  // Note: onerror="...this.style.display..." contains ".style." but never the
+  // attribute token `style="`, so it is correctly ignored.
+  const htmlPages = [
+    '/index.html',
+    '/about.html',
+    '/projects.html',
+    '/contact.html',
+    '/impressum.html',
+    '/datenschutz.html',
+    '/404.html',
+  ];
+
+  for (const path of htmlPages) {
+    test(`${path} has no inline style attribute`, async ({ request }) => {
+      const response = await request.get(path);
+      expect(response.status()).toBe(200);
+      const body = await response.text();
+      expect(body, `${path} must not contain an inline style="" attribute`).not.toMatch(/\sstyle\s*=/);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Move all **37 inline `style` attributes** (index 18, contact 8, about 6, 404 3, projects 2) into named classes in `css/style.css`, enforcing **AD-2**. New `:root` custom properties hold the LinkedIn brand blue and the availability-note tint so no colour is hard-coded at the point of use.
- **Preload** `arimo-latin-400-normal.woff2` + `arimo-latin-700-normal.woff2` on all 7 pages to cut the first-visit FOUT (italic variants intentionally not preloaded).
- Add regression tests: an **AD-2 guard** (no `style="` in any page's HTML) and **preload assertions** (400/700 normal, `type=font/woff2`, `crossorigin`; no italic preloads).

Behaviour-preserving refactor — **no visible change expected**. Verified in-browser via computed-style comparison: every refactored element renders pixel-identical (padding, gaps, font-sizes, theme-driven colours, the preserved cyan availability tint, LinkedIn `#0a66c2`). The `about.html` avatar `onerror` fallback still overrides the new `.avatar-fallback { display:none }` via its inline `display:flex`.

> Note: The availability note keeps its existing faint **cyan** tint (`rgba(0,212,255,·)`) to guarantee zero visual change. This is a leftover from the pre-gold theme and is inconsistent with the gold accent — worth normalising in a separate PR.

Closes #72

## Test plan
- [x] Full Playwright suite passes (730 tests green)
- [x] New AD-2 guard + preload tests pass (21 tests)
- [x] No `style="` attribute remains on any of the 7 pages
- [x] Computed styles verified pixel-identical (light theme + avatar onerror fallback)
- [ ] Reviewer spot-check: value-props / contact icons / availability note in dark + light, desktop + mobile

_Screenshots omitted: this is a non-visual refactor and the Docker browser's output filesystem isn't host-accessible; equivalence was proven via computed-style assertions instead._