### PR TITLE
style: align availability note with gold accent tint

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -63,8 +63,8 @@
   --shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
   --transition: 0.3s ease;
   --color-linkedin: #0a66c2;
-  --available-bg: rgba(0, 212, 255, 0.06);
-  --available-border: rgba(0, 212, 255, 0.2);
+  --available-bg: rgba(255, 194, 80, 0.06);
+  --available-border: rgba(255, 194, 80, 0.2);
   /* Theme-sensitive surface colours (overridden in light mode) */
   --navbar-bg: rgba(16, 14, 8, 0.92);
   --dot-color: rgba(255, 255, 255, 0.04);


### PR DESCRIPTION
## Summary
- The "Aktuell verfügbar" box on the contact page kept a leftover **cyan** tint (`rgba(0,212,255,·)`) from the pre-gold theme, clashing with the gold-bordered contact cards around it.
- Switch `--available-bg` / `--available-border` to the accent **gold** `rgba(255,194,80,·)` — the same tint convention already used by `.contact-item-icon` and `.contact-item:hover`.

This is the follow-up flagged in #74. Pure two-value CSS change; the "✅ Aktuell verfügbar" text keeps `var(--accent)` and is unchanged.

```diff
- --available-bg: rgba(0, 212, 255, 0.06);
- --available-border: rgba(0, 212, 255, 0.2);
+ --available-bg: rgba(255, 194, 80, 0.06);
+ --available-border: rgba(255, 194, 80, 0.2);
```

## Screenshots
Before/after comparison (Dark + Light), rendered from `main` vs this branch:

**→ https://claude.ai/code/artifact/70d65694-2022-4f1b-895d-263cb0785781**

_(Private Artifact — hosted comparison page; keeps the repo free of throwaway PNG assets.)_

## Test plan
- [x] Full Playwright suite passes (730 green — pure colour value, no test asserts the old tint)
- [x] Verified in-browser in both themes: box now matches the surrounding gold cards
- [ ] Reviewer: confirm the availability box reads as part of the card set in Dark + Light