### PR TITLE
ci: cache Playwright browsers and parallelize test run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: Tests
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -20,7 +23,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: latest
+          node-version: lts/*
           cache: npm
           cache-dependency-path: tests/package-lock.json
 
@@ -28,8 +31,30 @@ jobs:
         run: npm ci
         working-directory: tests
 
-      - name: Install Playwright browsers
+      - name: Resolve Playwright version
+        id: pw
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+        working-directory: tests
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      # Cache miss (first run / Playwright upgrade): download the browser and its
+      # apt system libraries. This is the slow path and runs only rarely.
+      - name: Install Playwright browsers with system deps
+        if: steps.pw-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+        working-directory: tests
+
+      # Cache hit (the common case): the browser binary is already restored, so this
+      # is a near-instant verify. No apt-get — ubuntu-latest ships the required libs.
+      - name: Verify cached Playwright browser
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install chromium
         working-directory: tests
 
       - name: Run Playwright tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Resolve Playwright version
         id: pw
-        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(node -p 'require("@playwright/test/package.json").version')" >> "$GITHUB_OUTPUT"
         working-directory: tests
 
       - name: Cache Playwright browsers

--- a/tests/playwright.config.js
+++ b/tests/playwright.config.js
@@ -15,7 +15,7 @@ module.exports = defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 2 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'line',
 
   use: {


### PR DESCRIPTION
## Problem

CI runs take **4–8 min** (worst case ~7m55s). Step-level timing of two real runs showed two bottlenecks:

| Step | Run A | Run B |
|------|-------|-------|
| Playwright browsers install | **4m11s** ⚠️ | 23s |
| Playwright tests | 3m23s | 3m17s |

1. **Browser install is uncached and variable (23s–4m11s).** `playwright install --with-deps chromium` re-downloads Chromium *and* runs `apt-get` for system libs on every run — the `apt-get` path is the 4-minute outlier.
2. **Test run underutilizes the runner.** `workers: 2` on `ubuntu-latest` runners that have 4 vCPUs.

## Changes

- **Cache `~/.cache/ms-playwright`** keyed on the Playwright version. On a cache hit, skip `--with-deps` and just verify the binary (no `apt-get` — `ubuntu-latest` already ships the required libs). Full `--with-deps` install only on cache miss (first run / Playwright upgrade).
- **Trigger on `push` to `main`** so `main` populates the base-branch cache that all PRs can restore. GitHub only shares caches from the base branch to PRs — sibling PR-branch caches are isolated — so without a `main` run every new PR branch would be a cache miss. Side benefit: `main` stays continuously tested.
- **Bump CI `workers` 2 → 4** to use all vCPUs (~3.3 min → ~2 min).
- **Pin `node-version` to `lts/*`** to avoid incidental Node re-downloads.

No new runtime dependency, no Docker — the zero-dependency site principle stays intact. This is CI config only.

## Expected impact

~4–8 min → **consistent ~2.5–3 min** once the cache is warm.

> [!NOTE]
> The **first PR run here is still a cache miss** (full install). The shared cache only fills after this merges to `main` and the `push`-triggered run completes; subsequent PRs then hit the fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)