### PR TITLE
ci: cancel superseded workflow runs on new pushes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,12 @@ on:
 permissions:
   contents: read
 
+# Cancel an in-progress run when a newer commit is pushed to the same ref, so
+# rapid pushes to a PR don't pile up redundant runs.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Playwright Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ permissions:
 # Cancel an in-progress run when a newer commit is pushed to the same ref, so
 # rapid pushes to a PR don't pile up redundant runs.
 concurrency:
-  group: tests-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Adds a `concurrency` group (keyed on the git ref, `cancel-in-progress: true`) so a new push to a PR cancels its still-running older run instead of stacking redundant runs. Small CI-minute saver.

This PR also doubles as the **proof run** for #76's caching assumption: it is a fresh branch off `main`, so its CI run must restore the browser cache that the post-merge `main` run just populated. If the assumption holds, its `Install Playwright browsers with system deps` step is **skipped** and `Verify cached Playwright browser` runs instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)